### PR TITLE
Change to secure cdn

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = {
     book: {
         assets: "./book",
         js: [
-            "https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML&ver=2.3",
+            "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML&ver=2.4.0",
             "plugin.js"
         ]
     }


### PR DESCRIPTION
This is to prevent MathJax from being blocked (for websites using https), and also for security
reasons.

Note the ver=2.3 at the end of the url, this is for a temporary bug with the MathJax hosting.

(N.B. this is my very first pull request in my git life! I apologise in advance for any misuse!)
