### PR TITLE
Update CDN to recommended fixed version

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var crc = require('crc');
 var exec = require('child_process').exec;
-var mjAPI = require('mathjax-node/lib/mj-single.js');
+var mjAPI = require('mathjax-node/lib/main.js');
 
 var started = false;
 var countMath = 0;
@@ -118,7 +118,7 @@ function processBlock(blk) {
     @return {Object}
 */
 function getWebsiteAssets() {
-    var version = this.config.get('pluginsConfig.mathjax.version', '2.7.1');
+    var version = this.config.get('pluginsConfig.mathjax.version', '2.7.6');
 
     return {
         assets: "./book",

--- a/index.js
+++ b/index.js
@@ -118,12 +118,12 @@ function processBlock(blk) {
     @return {Object}
 */
 function getWebsiteAssets() {
-    var version = this.config.get('pluginsConfig.mathjax.version', 'latest');
+    var version = this.config.get('pluginsConfig.mathjax.version', '2.7.1');
 
     return {
         assets: "./book",
         js: [
-            'https://cdn.mathjax.org/mathjax/' + version + '/MathJax.js?config=TeX-AMS-MML_HTMLorMML',
+            'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' + version + '/MathJax.js?config=TeX-AMS-MML_HTMLorMML',
             'plugin.js'
         ]
     };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "gitbook": ">=3.0.0"
     },
     "dependencies": {
-        "mathjax-node": "2.0.0",
+        "mathjax-node": "1.2.1",
         "q": "^1.1.2",
         "crc": "^3.2.1"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "gitbook": ">=3.0.0"
     },
     "dependencies": {
-        "mathjax-node": "0.5.2",
+        "mathjax-node": "2.0.0",
         "q": "^1.1.2",
         "crc": "^3.2.1"
     },
@@ -31,7 +31,7 @@
             "version": {
                 "type": "string",
                 "title": "Version of MathJAX to use for website rendering",
-                "default": "2.7.1"
+                "default": "2.7.6"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
             "version": {
                 "type": "string",
                 "title": "Version of MathJAX to use for website rendering",
-                "default": "2.6-latest"
+                "default": "2.7.1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "gitbook": ">=3.0.0"
     },
     "dependencies": {
-        "mathjax-node": "1.2.1",
+        "mathjax-node": "1.3.0",
         "q": "^1.1.2",
         "crc": "^3.2.1"
     },


### PR DESCRIPTION
Required as CDN shut down: https://www.mathjax.org/cdn-shutting-down/